### PR TITLE
Fix crash with user data being null

### DIFF
--- a/src/AssistBackgroundClient.csproj
+++ b/src/AssistBackgroundClient.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Discord/DiscordPresence.cs
+++ b/src/Discord/DiscordPresence.cs
@@ -19,7 +19,8 @@ namespace AssistBackgroundClient.Discord
         #endregion
         public static readonly Button[] clientButtons =
         {
-            new() {Label = "Download Assist", Url = "https://cdn.rumblemike.com/AssistSetup.exe"}
+            new() {Label = "Download Assist", Url = "https://github.com/Rumblemike/Assist/releases/latest/download/AssistSetup.exe"},
+            new() {Label = "Join the Discord!", Url = "https://discord.gg/B43EndmEgW"}
         };
 
         public static ValorantPresence ValorantPresence;

--- a/src/Discord/ValorantPresence.cs
+++ b/src/Discord/ValorantPresence.cs
@@ -29,7 +29,7 @@ namespace AssistBackgroundClient.Discord
 
         public async Task ConnectionLoop()
         {
-            while (currentUser.tokenData.access is null)
+            while (currentUser.UserData is null)
             {
                 Console.WriteLine("Authing");
                 try
@@ -40,6 +40,7 @@ namespace AssistBackgroundClient.Discord
                 {
                     Console.WriteLine("Error");
                     Console.WriteLine(ex.Message);
+                    currentUser = new RiotUser(); //Work around a bug (?) in valnet which attempt to re-set the default headers which throws an exception
                 }
                 Console.WriteLine("Looking for Game");
                 Thread.Sleep(10000);

--- a/src/Discord/ValorantPresence.cs
+++ b/src/Discord/ValorantPresence.cs
@@ -227,14 +227,15 @@ namespace AssistBackgroundClient.Discord
                 privacy = DiscordRPC.Party.PrivacySetting.Public;
             }
 
-            string state = $"{userPrivateData.partyOwnerMatchScoreAllyTeam} - {userPrivateData.partyOwnerMatchScoreEnemyTeam}";
+            string state = $"Party: ";
 
             string details;
             if (userPrivateData.partyState.Contains("CUSTOM_GAME"))
-                details = "Custom Game";
+                details = $"Custom Game || {userPrivateData.partyOwnerMatchScoreAllyTeam} - {userPrivateData.partyOwnerMatchScoreEnemyTeam}";
             else
             {
-                details = char.ToUpper(userPrivateData.queueId[0]) + userPrivateData.queueId.Substring(1);
+                var queue = await DetermineQueueKey();
+                details = $"{queue} || {userPrivateData.partyOwnerMatchScoreAllyTeam} - {userPrivateData.partyOwnerMatchScoreEnemyTeam}";
             }
 
             string mapName = await DetermineMapKey();
@@ -299,6 +300,26 @@ namespace AssistBackgroundClient.Discord
             }
 
         }
+
+        private async Task<string> DetermineQueueKey()
+        {
+            switch (userPrivateData.queueId)
+            {
+                case "ggteam":
+                    return "Escalation";
+                case "deathmatch":
+                    return "Deathmatch";
+                case "spikerush":
+                    return "SpikeRush";
+                case "competitive":
+                    return "Competitive";
+                case "unrated":
+                    return "Unrated";
+                default:
+                    return "VALORANT";
+            }
+
+        }
         #endregion
 
     }
@@ -306,3 +327,4 @@ namespace AssistBackgroundClient.Discord
 
 
 }
+


### PR DESCRIPTION
If the background client is started at the same time, or within a few seconds, of the game, it's possible for the ValNet entitlements/v1/token request to be made too early, which causes the access token to be set, but not the user data, so the client crashes later on when trying to access the data. Instead, just keep retrying until the user data is non-null (i.e. all requests succeeded)

Please test this, because my vanguard is crashing a bunch now and I'm not sure if it's because of this or it's just got into a bad state and I haven't rebooted yet.