### PR TITLE
Set as Background Process

### DIFF
--- a/src/AssistBackgroundClient.csproj
+++ b/src/AssistBackgroundClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
   </PropertyGroup>


### PR DESCRIPTION
To me, That little console window is kinda annoying. And also to someone who's not that into tech, it can be kinda scary to them. Setting it to windows application (which with no windows process, it doesn't show up) should be just fine. I tested it and it works.

If I'm doing something wrong please tell me (and also decline my pull request). I'm completely new to C# and Windows application. I still want to propose the idea of application running in background though.